### PR TITLE
Improve SQL query experience

### DIFF
--- a/packages/builder/src/components/common/CodeMirrorEditor.svelte
+++ b/packages/builder/src/components/common/CodeMirrorEditor.svelte
@@ -41,6 +41,7 @@ export const EditorModes = {
   const dispatch = createEventDispatcher()
   let textarea
   let editor
+  let container
 
   // Keep editor up to date with value
   // Creates an instance of a code mirror editor
@@ -113,10 +114,14 @@ $: editor?.setOption("mode", mode)
 
   onMount(() => {
     // Create the editor with initial value
-    createEditor(mode, value)
+    const resizeObserver = new ResizeObserver(() => editor?.refresh())
+    resizeObserver.observe(container)
+
+    createEditor(mode, value).then(() => editor?.refresh())
 
     // Clean up editor on unmount
     return () => {
+      resizeObserver.disconnect()
       if (editor) {
         editor.toTextArea()
       }
@@ -130,6 +135,7 @@ $: editor?.setOption("mode", mode)
   </div>
 {/if}
 <div
+  bind:this={container}
   style={`--code-mirror-height: ${height}px; --code-mirror-resize: ${resize}`}
 >
   <textarea tabindex="0" bind:this={textarea} readonly {value}></textarea>

--- a/packages/builder/src/components/design/Panel.svelte
+++ b/packages/builder/src/components/design/Panel.svelte
@@ -10,6 +10,8 @@ export let showCloseButton: boolean | undefined = false
 export let onClickAddButton: () => void = () => {}
 export let onClickBackButton: () => void = () => {}
 export let onClickCloseButton: () => void = () => {}
+export let onClickHeader: () => void = () => {}
+export let headerClickable: boolean | undefined = false
 export let borderLeft: boolean | undefined = false
 export let borderRight: boolean | undefined = false
 export let borderBottomHeader: boolean | undefined = true
@@ -30,6 +32,11 @@ $: panelStyle =
     : resizable
       ? `flex: 1 1 auto; min-width: 260px;`
       : undefined
+
+const handleCloseButtonClick = (event: MouseEvent) => {
+  event.stopPropagation()
+  onClickCloseButton()
+}
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -43,11 +50,14 @@ $: panelStyle =
   style={panelStyle}
 >
   {#if title || customTitleContent}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div
       class="header"
       class:custom={customHeaderContent}
       class:borderBottom={borderBottomHeader}
       class:noHeaderBorder
+      class:clickable={headerClickable}
+      on:click={headerClickable ? onClickHeader : undefined}
     >
       {#if showBackButton}
         <Icon name="arrow-left" hoverable on:click={onClickBackButton} />
@@ -81,7 +91,11 @@ $: panelStyle =
         </div>
       {/if}
       {#if showCloseButton}
-        <Icon name={closeButtonIcon} hoverable on:click={onClickCloseButton} />
+        <Icon
+          name={closeButtonIcon}
+          hoverable
+          on:click={handleCloseButtonClick}
+        />
       {/if}
     </div>
   {/if}
@@ -187,6 +201,10 @@ $: panelStyle =
   }
   .header.custom {
     border: none;
+  }
+
+  .header.clickable {
+    cursor: pointer;
   }
   .custom-content-wrap {
     border-bottom: var(--border-light);

--- a/packages/builder/src/components/integration/ExtraQueryConfig.svelte
+++ b/packages/builder/src/components/integration/ExtraQueryConfig.svelte
@@ -17,21 +17,49 @@ $: extraFields = Object.keys(config).map((key) => ({
 $: extraQueryFields = query.fields.extra || {}
 </script>
 
-{#each extraFields as { key, displayName, type }}
-  <Label>{displayName}</Label>
-  {#if type === "string"}
-    <Input
-      on:change={() => populateExtraQuery(extraQueryFields)}
-      bind:value={extraQueryFields[key]}
-    />
-  {/if}
+<div class="extra-fields">
+  {#each extraFields as { key, displayName, type }}
+    <div class="extra-field">
+      <Label>{displayName}</Label>
+      {#if type === "string"}
+        <Input
+          on:change={() => populateExtraQuery(extraQueryFields)}
+          bind:value={extraQueryFields[key]}
+        />
+      {/if}
 
-  {#if type === "list"}
-    <Select
-      on:change={() => populateExtraQuery(extraQueryFields)}
-      bind:value={extraQueryFields[key]}
-      options={config[key].data[query.queryVerb]}
-      getOptionLabel={current => current}
-    />
-  {/if}
-{/each}
+      {#if type === "list"}
+        <Select
+          on:change={() => populateExtraQuery(extraQueryFields)}
+          bind:value={extraQueryFields[key]}
+          options={config[key].data[query.queryVerb]}
+          getOptionLabel={current => current}
+        />
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .extra-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--spacing-l);
+  }
+
+  .extra-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+
+  .extra-field :global(.spectrum-Form-item) {
+    width: 100%;
+  }
+
+  @media (max-width: 700px) {
+    .extra-fields {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/builder/src/components/integration/QueryEditor.svelte
+++ b/packages/builder/src/components/integration/QueryEditor.svelte
@@ -20,9 +20,11 @@ export let tab = true
 export let mode
 export let editorHeight = 500
 export let editorWidth = 640
+export let autoHeight = false
 
 let width
 let height
+$: sqlMode = mode === "sql" || mode?.startsWith("text/x-")
 
 // We have to expose set and update methods, rather
 // than making this state-driven through props,
@@ -36,7 +38,10 @@ export async function set(new_value, new_mode) {
 
   value = new_value
   updating_externally = true
-  if (editor) editor.setValue(value)
+  if (editor) {
+    editor.setValue(value)
+    adjustEditorHeight()
+  }
   updating_externally = false
 }
 
@@ -47,6 +52,7 @@ export function update(new_value) {
     const { left, top } = editor.getScrollInfo()
     editor.setValue(value)
     editor.scrollTo(left, top)
+    adjustEditorHeight()
   }
 }
 
@@ -83,10 +89,29 @@ const modes = {
   },
 }
 
+const bindingOverlay = {
+  token(stream) {
+    if (stream.match(/\{\{[^}]*\}\}/)) {
+      return "binding"
+    }
+
+    while (!stream.match(/\{\{/, false) && stream.next() != null) {}
+    return null
+  },
+}
+
 const refs = {}
 let editor
 let updating_externally = false
 let destroyed = false
+
+function adjustEditorHeight() {
+  if (!autoHeight || !editor) return
+
+  const lineHeight = editor.defaultTextHeight()
+  const lineCount = Math.max(editor.lineCount(), 3)
+  editor.setSize(null, `${lineCount * lineHeight + 8}px`)
+}
 
 async function createEditor(mode) {
   if (destroyed || !CodeMirror) return
@@ -99,7 +124,7 @@ async function createEditor(mode) {
     indentWithTabs: true,
     indentUnit: 2,
     tabSize: 2,
-    value: "",
+    value: value || "",
     mode: modes[mode] || {
       name: mode,
     },
@@ -116,10 +141,6 @@ async function createEditor(mode) {
       "Shift-Tab": tab,
     }
 
-  // Creating a text editor is a lot of work, so we yield
-  // the main thread for a moment. This helps reduce jank
-  if (first) await sleep(50)
-
   if (destroyed) return
 
   CodeMirror.commands.autocomplete = (cm) => {
@@ -127,8 +148,10 @@ async function createEditor(mode) {
   }
 
   editor = CodeMirror.fromTextArea(refs.editor, opts)
+  if (sqlMode) editor.addOverlay(bindingOverlay)
 
   editor.on("change", (instance) => {
+    adjustEditorHeight()
     if (!updating_externally) {
       const value = instance.getValue()
       dispatch("change", { value })
@@ -147,14 +170,7 @@ async function createEditor(mode) {
   //   })
   // })
 
-  if (first) await sleep(50)
   editor.refresh()
-
-  first = false
-}
-
-function sleep(ms) {
-  return new Promise((fulfil) => setTimeout(fulfil, ms))
 }
 
 $: if (editor && width && height) {
@@ -163,7 +179,10 @@ $: if (editor && width && height) {
 
 onMount(() => {
   createEditor(mode).then(() => {
-    if (editor) editor.setValue(value || "")
+    if (editor) {
+      editor.refresh()
+      adjustEditorHeight()
+    }
   })
 
   return () => {
@@ -172,14 +191,14 @@ onMount(() => {
   }
 })
 
-let first = true
 </script>
 
 {#if label}
   <Label small>{label}</Label>
 {/if}
 <div
-  style={`--code-mirror-height: ${editorHeight}px; --code-mirror-width: ${editorWidth}px;`}
+  class:sqlMode
+  style={`--code-mirror-height: ${editorHeight}px; --code-mirror-width: ${editorWidth}px; --code-mirror-resize: ${autoHeight ? "none" : "vertical"};`}
 >
   <textarea tabindex="0" bind:this={refs.editor} readonly {value}></textarea>
 </div>
@@ -195,9 +214,20 @@ let first = true
 
   div :global(.CodeMirror) {
     height: var(--code-mirror-height);
+    min-height: 200px;
     border-radius: var(--border-radius-s);
     font-family: var(--font-mono);
     line-height: 1.3;
-    resize: vertical;
+    resize: var(--code-mirror-resize);
+  }
+
+  div.sqlMode :global(span.cm-keyword) {
+    color: #2BAB72 !important;
+    font-weight: 700;
+  }
+
+  div.sqlMode :global(span.cm-binding) {
+    color: #6E99C4 !important;
+    font-weight: 400 !important;
   }
 </style>

--- a/packages/builder/src/components/integration/QueryEditor.svelte
+++ b/packages/builder/src/components/integration/QueryEditor.svelte
@@ -190,7 +190,6 @@ onMount(() => {
     if (editor) editor.toTextArea()
   }
 })
-
 </script>
 
 {#if label}

--- a/packages/builder/src/components/integration/QueryViewer.svelte
+++ b/packages/builder/src/components/integration/QueryViewer.svelte
@@ -3,12 +3,12 @@ import {
   ActionButton,
   Body,
   Checkbox,
-  Divider,
-  Heading,
   Input,
   Label,
   notifications,
   Select,
+  Tab,
+  Tabs,
 } from "@supertoolmake/bbui"
 import { Utils } from "@supertoolmake/frontend-core"
 import { ValidQueryNameRegex } from "@supertoolmake/shared-core"
@@ -35,12 +35,15 @@ import type {
 
 export let query: Query
 let queryHash = ""
+let schemaHash = ""
 
 let loading = false
 let modified = false
 let scrolling = false
-let showSidePanel = false
+let resultsCollapsed = true
+let activeSettingsTab = "Query"
 let nameError: string | null = null
+let parsedQueryKey = ""
 
 let newQuery: Query
 
@@ -56,6 +59,12 @@ let pagination: PaginationConfig | undefined
 
 const parseQuery = (query: Query) => {
   modified = false
+  const queryKey = `${query.datasourceId}:${query._id || "new"}`
+  const queryChanged = queryKey !== parsedQueryKey
+  if (queryChanged) {
+    resultsCollapsed = true
+    parsedQueryKey = queryKey
+  }
   const foundDatasource = $datasources.list.find((ds: Datasource) => ds._id === query.datasourceId)
   if (!foundDatasource) {
     return
@@ -68,6 +77,9 @@ const parseQuery = (query: Query) => {
   }
   integration = matchingIntegration
   schemaType = integration.query[query.queryVerb].type
+  if (queryChanged) {
+    activeSettingsTab = schemaType === "sql" ? "Query" : "Config"
+  }
 
   newQuery = cloneDeep(query)
   // init schema from the query if one already exists
@@ -91,18 +103,20 @@ const parseQuery = (query: Query) => {
   }
 
   queryHash = JSON.stringify(newQuery)
+  schemaHash = JSON.stringify(schema)
 }
 
 const checkIsModified = (newQuery: Query) => {
   const newQueryHash = JSON.stringify(newQuery)
-  modified = newQueryHash !== queryHash
+  const newSchemaHash = JSON.stringify(schema)
+  modified = newQueryHash !== queryHash || newSchemaHash !== schemaHash
 
   return modified
 }
 
 async function runQuery({ suppressErrors = true }: { suppressErrors?: boolean } = {}) {
   try {
-    showSidePanel = true
+    resultsCollapsed = false
     loading = true
     const response = await queries.preview({ ...newQuery, schema })
     if (response.rows.length === 0) {
@@ -116,6 +130,7 @@ async function runQuery({ suppressErrors = true }: { suppressErrors?: boolean } 
 
     schema = response.schema
     rows = response.rows
+    checkIsModified(newQuery)
 
     // Initialize pagination for SQL Read queries
     if (newQuery.queryVerb === "read" && schemaType === "sql") {
@@ -145,7 +160,6 @@ async function runQuery({ suppressErrors = true }: { suppressErrors?: boolean } 
 
 async function saveQuery() {
   try {
-    showSidePanel = true
     loading = true
     const response = await queries.save(newQuery.datasourceId, {
       ...newQuery,
@@ -153,6 +167,12 @@ async function saveQuery() {
       nestedSchemaFields,
     })
 
+    if (response?._id) {
+      newQuery._id = response._id
+    }
+    queryHash = JSON.stringify(newQuery)
+    schemaHash = JSON.stringify(schema)
+    modified = false
     notifications.success("Query saved successfully")
     return response
   } catch (error) {
@@ -165,6 +185,24 @@ async function saveQuery() {
 function resetDependentFields() {
   if (newQuery.fields.extra) {
     newQuery.fields.extra = {} as Query["fields"]["extra"]
+  }
+}
+
+function handleQueryVerbChange() {
+  resetDependentFields()
+  schemaType = integration.query[newQuery.queryVerb].type
+
+  if (newQuery.queryVerb === "read" && schemaType === "sql") {
+    if (!newQuery.fields.pagination) {
+      newQuery.fields.pagination = {
+        enabled: false,
+        offsetBinding: "offset",
+        limitBinding: "limit",
+      }
+    }
+    pagination = newQuery.fields.pagination
+  } else {
+    pagination = undefined
   }
 }
 
@@ -199,6 +237,7 @@ const handleScroll = (e: Event) => {
 const handleSchemaChange = (newSchema?: Record<string, QuerySchema | string>) => {
   if (newSchema) {
     schema = newSchema
+    checkIsModified(newQuery)
   }
 }
 
@@ -210,7 +249,11 @@ async function handleKeyDown(evt: KeyboardEvent) {
 
 $: parseQuery(query)
 
-const debouncedCheckIsModified = Utils.debounce(checkIsModified, 1000)
+$: if (activeSettingsTab === "Pagination" && !(pagination && newQuery.queryVerb === "read")) {
+  activeSettingsTab = schemaType === "sql" ? "Query" : "Config"
+}
+
+const debouncedCheckIsModified = Utils.debounce(checkIsModified, 100)
 
 $: debouncedCheckIsModified(newQuery)
 </script>
@@ -219,55 +262,17 @@ $: debouncedCheckIsModified(newQuery)
 <div class="queryViewer">
   <div class="main">
     <div class="header" class:scrolling>
-      <div class="title">
-        <Body size="S">
-          {newQuery.name || "Untitled query"}<span class="unsaved"
-            >{modified ? "*" : ""}</span
-          >
-        </Body>
-      </div>
-      <div class="controls">
-        <ConnectedQueryScreens sourceId={query._id!} />
-        <ActionButton
-          icon="play"
-          disabled={loading}
-          on:click={() => runQuery()}
-        >
-          Run query
-        </ActionButton>
-        <div class="tooltip" title="Run your query to enable saving">
-          <ActionButton
-            icon="floppy-disk"
-            on:click={async () => {
-              const response = await saveQuery()
-
-              // When creating a new query the initally passed in query object will have no id.
-              if (response?._id && !newQuery._id) {
-                // Set the comparison query hash to match the new query so that the user doesn't
-                // get nagged when navigating to the edit view
-                queryHash = JSON.stringify(newQuery)
-                $goto(`../../${response._id}`)
-              }
-            }}
-            disabled={!!(
-              loading ||
-              !newQuery.name ||
-              nameError ||
-              rows.length === 0
-            )}
-          >
-            Save
-          </ActionButton>
-        </div>
-      </div>
-    </div>
-
-    <div class="body" on:scroll={handleScroll}>
-      <div class="bodyInner">
-        <div class="configField">
-          <Label>Name</Label>
+      <div class="queryDetails">
+        <div class="queryName">
           <Input
             value={newQuery.name}
+            quiet
+            autofocus={!newQuery._id}
+            on:focus={event => {
+              if (!newQuery._id && event.currentTarget instanceof HTMLInputElement) {
+                event.currentTarget.select()
+              }
+            }}
             on:input={e => {
               let newValue =
                 e.currentTarget instanceof HTMLInputElement
@@ -282,164 +287,211 @@ $: debouncedCheckIsModified(newQuery)
             }}
             error={nameError || undefined}
           />
-          {#if integration.query}
-            <Label>Function</Label>
+        </div>
+        {#if integration.query}
+          <div class="field functionField">
             <Select
               bind:value={newQuery.queryVerb}
-              on:change={resetDependentFields}
+              on:change={handleQueryVerbChange}
+              autoWidth
               options={Object.keys(integration.query)}
               getOptionLabel={verb =>
                 integration.query[verb]?.displayName || capitalise(verb)}
             />
-            <Label>Access</Label>
-            <AccessLevelSelect query={newQuery} label={undefined} />
-            {#if integration?.extra && newQuery.queryVerb}
-              <ExtraQueryConfig
-                query={newQuery}
-                {populateExtraQuery}
-                config={integration.extra}
-              />
-            {/if}
-          {/if}
-        </div>
-
-        <Divider />
-
-        <div class="heading">
-          <Heading weight="heavy" size="XS">Query</Heading>
-        </div>
-        <div class="copy">
-          <Body size="S">
-            {#if schemaType === "sql"}
-              Add some SQL to query your data
-            {:else if schemaType === "json"}
-              Add some JSON to query your data
-            {:else if schemaType === "fields"}
-              Add some fields to query your data
-            {:else}
-              Enter your query below
-            {/if}
-          </Body>
-        </div>
-        <IntegrationQueryEditor
-          noLabel
-          {datasource}
-          bind:query={newQuery}
-          height={200}
-          schema={integration.query[newQuery.queryVerb]}
-        />
-
-        <Divider />
-
-        <div class="heading">
-          <Heading weight="heavy" size="XS">Bindings</Heading>
-        </div>
-        <div class="copy">
-          <Body size="S">
-            Bindings come in two parts: the binding name, and a default/fallback
-            value. These bindings can be used as Handlebars expressions
-            throughout the query.
-          </Body>
-        </div>
-        {#key newQuery.parameters}
-          <BindingBuilder
-            queryBindings={newQuery.parameters}
-            on:change={e => {
-              newQuery.parameters = e.detail.map(
-                (binding: { name: string; value: string }) => {
-                  return {
-                    name: binding.name,
-                    default: binding.value,
-                  }
-                }
-              )
-            }}
-          />
-        {/key}
-
-        {#if pagination && newQuery.queryVerb === "read"}
-          <Divider />
-          <div class="heading">
-            <Heading weight="heavy" size="XS">Pagination</Heading>
-          </div>
-          <div class="copy">
-            <Body size="S">
-              Enable pagination to support limit and offset parameters in this
-              query.
-            </Body>
-          </div>
-          <div class="pagination">
-            {#key pagination.enabled}
-              <Checkbox
-                text="Enable pagination"
-                bind:value={pagination.enabled}
-                on:change={e => setPaginationField("enabled", e.detail)}
-              />
-            {/key}
-            {#if pagination.enabled}
-              <div class="pagination-inputs">
-                <Input
-                  label="Offset binding name"
-                  placeholder="e.g., offset"
-                  value={pagination.offsetBinding}
-                  on:change={e => setPaginationField("offsetBinding", e.detail)}
-                />
-                <Input
-                  label="Limit binding name"
-                  placeholder="e.g., limit"
-                  value={pagination.limitBinding}
-                  on:change={e => setPaginationField("limitBinding", e.detail)}
-                />
-              </div>
-            {/if}
           </div>
         {/if}
-
-        <Divider />
-        <div class="heading">
-          <Heading weight="heavy" size="XS">Transformer</Heading>
+      </div>
+      <div class="controls">
+        <div class="access">
+          <Label>Access</Label>
+          <AccessLevelSelect query={newQuery} label={undefined} />
         </div>
-        <div class="copy">
-          <Body size="S">
-            Add a JavaScript function to transform the query result.
-          </Body>
-        </div>
-        <CodeMirrorEditor
-          label={undefined}
-          height={200}
-          value={newQuery.transformer || ""}
-          resize="vertical"
-          on:change={e => (newQuery.transformer = e.detail)}
-        />
+        <ConnectedQueryScreens sourceId={query._id!} />
       </div>
     </div>
-  </div>
 
-  <div class:showSidePanel class="sidePanel">
-    <QueryViewerSidePanel
-      onClose={() => (showSidePanel = false)}
-      onSchemaChange={handleSchemaChange}
-      {rows}
-      {schema}
-    />
+    <div class="body" on:scroll={handleScroll}>
+      <div class="bodyInner">
+        <div class="tabsToolbar">
+          <div class="settingsTabs">
+          <Tabs bind:selected={activeSettingsTab} quiet noPadding noHorizPadding onTop>
+            {#if schemaType !== "sql"}
+              <Tab title="Config">
+                <div class="tabSection">
+                  {#if integration?.extra && newQuery.queryVerb}
+                    <div class="extraQueryConfig">
+                      <ExtraQueryConfig
+                        query={newQuery}
+                        {populateExtraQuery}
+                        config={integration.extra}
+                      />
+                    </div>
+                  {/if}
+                </div>
+              </Tab>
+            {/if}
+            <Tab title="Query">
+              <div class="tabSection queryTab">
+                <div class="copy">
+                  <Body size="S">
+                    {#if schemaType === "sql"}
+                      Add some SQL to query your data
+                    {:else if schemaType === "json"}
+                      Add some JSON to query your data
+                    {:else if schemaType === "fields"}
+                      Add some fields to query your data
+                    {:else}
+                      Enter your query below
+                    {/if}
+                  </Body>
+                </div>
+                <IntegrationQueryEditor
+                  noLabel
+                  {datasource}
+                  bind:query={newQuery}
+                  height={200}
+                  autoHeight={schemaType === "sql"}
+                  schema={integration.query[newQuery.queryVerb]}
+                />
+
+                <div class:collapsed={resultsCollapsed} class="resultsPanel">
+                  <QueryViewerSidePanel
+                    bind:collapsed={resultsCollapsed}
+                    onSchemaChange={handleSchemaChange}
+                    {rows}
+                    {schema}
+                  />
+                </div>
+              </div>
+            </Tab>
+            <Tab title="Bindings">
+              <div class="tabSection">
+                <div class="copy">
+                  <Body size="S">
+                    Bindings come in two parts: the binding name, and a default/fallback
+                    value. These bindings can be used as Handlebars expressions
+                    throughout the query.
+                  </Body>
+                </div>
+                {#key newQuery.parameters}
+                  <BindingBuilder
+                    queryBindings={newQuery.parameters}
+                    on:change={e => {
+                      newQuery.parameters = e.detail.map(
+                        (binding: { name: string; value: string }) => {
+                          return {
+                            name: binding.name,
+                            default: binding.value,
+                          }
+                        }
+                      )
+                    }}
+                  />
+                {/key}
+              </div>
+            </Tab>
+            {#if pagination && newQuery.queryVerb === "read"}
+              <Tab title="Pagination">
+                <div class="tabSection">
+                  <div class="copy">
+                    <Body size="S">
+                      Enable pagination to support limit and offset parameters in
+                      this query.
+                    </Body>
+                  </div>
+                  <div class="pagination">
+                    {#key pagination.enabled}
+                      <Checkbox
+                        text="Enable pagination"
+                        bind:value={pagination.enabled}
+                        on:change={e => setPaginationField("enabled", e.detail)}
+                      />
+                    {/key}
+                    {#if pagination.enabled}
+                      <div class="pagination-inputs">
+                        <Input
+                          label="Offset binding name"
+                          placeholder="e.g., offset"
+                          value={pagination.offsetBinding}
+                          on:change={e =>
+                            setPaginationField("offsetBinding", e.detail)}
+                        />
+                        <Input
+                          label="Limit binding name"
+                          placeholder="e.g., limit"
+                          value={pagination.limitBinding}
+                          on:change={e =>
+                            setPaginationField("limitBinding", e.detail)}
+                        />
+                      </div>
+                    {/if}
+                  </div>
+                </div>
+              </Tab>
+            {/if}
+            <Tab title="Transformer">
+              <div class="tabSection">
+                <div class="copy">
+                  <Body size="S">
+                    Add a JavaScript function to transform the query result.
+                  </Body>
+                </div>
+                <CodeMirrorEditor
+                  label={undefined}
+                  height={200}
+                  value={newQuery.transformer || ""}
+                  resize="vertical"
+                  on:change={e => (newQuery.transformer = e.detail)}
+                />
+              </div>
+            </Tab>
+          </Tabs>
+          </div>
+          <div class="controls">
+            <ActionButton
+              icon="play"
+              disabled={loading}
+              on:click={() => runQuery()}
+            >
+              Run query
+            </ActionButton>
+            <div class="tooltip" title="Change the query to enable saving">
+              <ActionButton
+                icon="floppy-disk"
+                on:click={async () => {
+                  const isNewQuery = !newQuery._id
+                  const response = await saveQuery()
+
+                  if (response?._id && isNewQuery) {
+                    // Set the comparison query hash to match the new query so that the user doesn't
+                    // get nagged when navigating to the edit view
+                    queryHash = JSON.stringify(newQuery)
+                    $goto(`../../${response._id}`)
+                  }
+                }}
+                disabled={!!(
+                  loading ||
+                  !newQuery.name ||
+                  nameError ||
+                  !modified
+                )}
+              >
+                Save
+              </ActionButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
 <style>
-  .unsaved {
-    color: var(--grey-5);
-    font-style: italic;
-  }
-
   .queryViewer {
     height: 100%;
     margin: -28px -40px -40px -40px;
     display: flex;
     flex: 1;
-  }
-
-  .queryViewer :global(.spectrum-Divider) {
-    margin: 35px 0;
   }
 
   .main {
@@ -451,8 +503,11 @@ $: debouncedCheckIsModified(newQuery)
 
   .header {
     align-items: center;
-    padding: 8px 10px 8px 16px;
+    padding: 8px 0 8px 16px;
     display: flex;
+    width: 100%;
+    max-width: calc(1050px + 23px);
+    box-sizing: border-box;
     border-bottom: 2px solid transparent;
     transition:
       border-bottom 130ms ease-out,
@@ -472,26 +527,52 @@ $: debouncedCheckIsModified(newQuery)
   }
 
   .bodyInner {
-    max-width: 520px;
-    margin: auto;
+    width: 100%;
+    max-width: 1050px;
+    margin: 0;
   }
 
-  .title {
-    /* width 0 paired with flex-grow necessary here for the truncation to work properly*/
-    width: 0;
+  .bodyInner :global(.CodeMirror) {
+    width: 100%;
+  }
+
+  .queryDetails {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--spacing-l);
     flex-grow: 1;
+    min-width: 0;
   }
 
-  .title :global(p) {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  .queryName {
+    width: min(360px, 100%);
+    min-width: 0;
+  }
+
+  .queryName :global(.spectrum-Form-item) {
+    width: 100%;
+  }
+
+  .queryName :global(.spectrum-Textfield-input) {
+    min-height: 40px;
+    font-size: 18px;
+  }
+
+  .functionField {
+    flex-shrink: 0;
   }
 
   .controls {
     display: flex;
     align-items: center;
+    gap: var(--spacing-m);
     flex-shrink: 0;
+  }
+
+  .access {
+    display: flex;
+    gap: var(--spacing-m);
+    align-items: center;
   }
 
   .tooltip {
@@ -524,19 +605,49 @@ $: debouncedCheckIsModified(newQuery)
     align-items: center;
   }
 
-  .configField {
-    display: grid;
-    grid-template-columns: 20% 1fr;
-    grid-gap: var(--spacing-l);
-    align-items: center;
+  .tabsToolbar {
+    position: relative;
   }
 
-  .configField :global(label) {
+  .settingsTabs {
+    width: 100%;
+    margin-bottom: var(--spacing-xl);
+  }
+
+  .settingsTabs :global(.spectrum-Tabs-content) {
+    margin-top: var(--spacing-l);
+  }
+
+  .tabsToolbar > .controls {
+    position: absolute;
+    top: 4px;
+    right: 0;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-xs);
+  }
+
+  .field :global(label) {
     color: var(--grey-6);
   }
 
-  .heading {
-    margin-bottom: 8px;
+  .field :global(.spectrum-Form-item) {
+    width: 100%;
+  }
+
+  .extraQueryConfig {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-l);
+    margin-top: 0;
+  }
+
+  .tabSection {
+    min-width: 0;
   }
 
   .copy {
@@ -547,20 +658,69 @@ $: debouncedCheckIsModified(newQuery)
     color: var(--grey-7);
   }
 
-  .sidePanel {
-    flex-shrink: 0;
-    height: 100%;
-    width: 0;
+  .resultsPanel {
+    height: 500px;
+    margin-top: 32px;
     overflow: hidden;
-    transition: width 150ms;
+    border: var(--border-light);
+    border-radius: var(--border-radius-s);
+    transition: height 150ms ease-out;
   }
 
-  .sidePanel :global(.panel) {
+  .resultsPanel.collapsed {
+    height: 48px;
+  }
+
+  .resultsPanel :global(.panel) {
+    width: 100%;
+    min-width: 0;
+    height: 100%;
+    flex: 1 1 auto;
+  }
+
+  .resultsPanel :global(.panel .body) {
     height: 100%;
   }
 
-  .showSidePanel {
-    width: 450px;
+  @media (max-width: 700px) {
+    .body {
+      padding: 16px 16px 64px;
+    }
+
+    .bodyInner {
+      width: 100%;
+    }
+
+    .tabsToolbar {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .tabsToolbar > .controls {
+      position: static;
+      align-self: flex-end;
+    }
+
+    .queryDetails {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .queryName {
+      width: 100%;
+    }
+
+    .resultsPanel {
+      height: 400px;
+    }
+
+    .resultsPanel.collapsed {
+      height: 48px;
+    }
+
+    .pagination-inputs {
+      grid-template-columns: 1fr;
+    }
   }
 
   .pagination {

--- a/packages/builder/src/components/integration/QueryViewerSidePanel/PreviewPanel.svelte
+++ b/packages/builder/src/components/integration/QueryViewerSidePanel/PreviewPanel.svelte
@@ -6,10 +6,16 @@ export let schema = {}
 export let rows = []
 export let maxRowsToDisplay = 5
 
+const rowsPerLoad = 50
+
 let rowsToDisplay
 $: rowsToDisplay = [...cloneDeep(rows).slice(0, maxRowsToDisplay)]
 
-$: additionalRows = rows.length - maxRowsToDisplay
+$: additionalRows = Math.max(rows.length - maxRowsToDisplay, 0)
+
+const loadMore = () => {
+  maxRowsToDisplay += rowsPerLoad
+}
 
 // Cast field in query preview response to number if specified by schema
 $: {
@@ -29,9 +35,7 @@ $: {
 <div class="table">
   <Table {schema} data={rowsToDisplay} allowEditing={false} />
   {#if additionalRows > 0}
-    <div class="show-more">
-      ...{additionalRows} further items
-    </div>
+    <button class="show-more" type="button" on:click={loadMore}>Load more</button>
   {/if}
 </div>
 
@@ -45,9 +49,19 @@ $: {
     display: flex;
     padding: 16px;
     justify-content: center;
+    width: 100%;
+    box-sizing: border-box;
+    color: var(--ink);
+    font: inherit;
+    cursor: pointer;
+    transition: background-color 130ms ease-out;
 
     background-color: var(--spectrum-global-color-gray-50);
     border: 1px solid var(--spectrum-alias-border-color-mid);
     border-top: 0;
+  }
+
+  .show-more:hover {
+    background-color: var(--spectrum-global-color-gray-100);
   }
 </style>

--- a/packages/builder/src/components/integration/QueryViewerSidePanel/index.svelte
+++ b/packages/builder/src/components/integration/QueryViewerSidePanel/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 import { ActionButton } from "@supertoolmake/bbui"
 import Panel from "@/components/design/Panel.svelte"
 import JSONPanel from "./JSONPanel.svelte"
@@ -8,44 +8,55 @@ import SchemaPanel from "./SchemaPanel.svelte"
 export let rows
 export let schema
 export let onSchemaChange = () => {}
-export let onClose = () => {}
+export let collapsed = false
 
 const tabs = ["JSON", "Schema", "Preview"]
-let activeTab = "JSON"
+let activeTab = "Preview"
+
+const toggleCollapse = () => {
+  collapsed = !collapsed
+}
 </script>
 
 <Panel
   showCloseButton
-  closeButtonIcon="RailRightClose"
-  onClickCloseButton={onClose}
+  closeButtonIcon={collapsed ? "caret-down" : "caret-up"}
+  onClickCloseButton={toggleCollapse}
+  onClickHeader={toggleCollapse}
+  headerClickable
   title="Query results"
   icon={"SQLQuery"}
-  borderLeft
-  extraWide
 >
   <div slot="panel-header-content">
-    <div class="settings-tabs">
-      {#each tabs as tab}
-        <ActionButton
-          size="M"
-          quiet
-          selected={activeTab === tab}
-          on:click={() => {
-            activeTab = tab
-          }}
-        >
-          {tab}
-        </ActionButton>
-      {/each}
-    </div>
+    {#if !collapsed}
+      <div class="settings-tabs">
+        {#each tabs as tab}
+          <ActionButton
+            size="M"
+            quiet
+            selected={activeTab === tab}
+            on:click={() => {
+              activeTab = tab
+            }}
+          >
+            {tab}
+          </ActionButton>
+          {#if tab === "Preview"}
+            <span class="row-count">{rows?.length ?? 0} rows</span>
+          {/if}
+        {/each}
+      </div>
+    {/if}
   </div>
   <div class="content">
-    {#if activeTab === "JSON"}
-      <JSONPanel data={rows?.length === 1 ? rows[0] : rows || {}} />
-    {:else if activeTab === "Schema"}
-      <SchemaPanel {onSchemaChange} {schema} />
-    {:else}
-      <PreviewPanel {schema} {rows} />
+    {#if !collapsed}
+      {#if activeTab === "JSON"}
+        <JSONPanel data={rows?.length === 1 ? rows[0] : rows || {}} />
+      {:else if activeTab === "Schema"}
+        <SchemaPanel {onSchemaChange} {schema} />
+      {:else}
+        <PreviewPanel {schema} {rows} />
+      {/if}
     {/if}
   </div>
 </Panel>
@@ -53,9 +64,16 @@ let activeTab = "JSON"
 <style>
   .settings-tabs {
     display: flex;
+    align-items: center;
     gap: var(--spacing-s);
     padding: 0 var(--spacing-l);
     padding-bottom: var(--spacing-l);
+  }
+
+  .row-count {
+    margin-left: auto;
+    color: var(--grey-6);
+    white-space: nowrap;
   }
 
   .content {

--- a/packages/builder/src/components/integration/codemirror.js
+++ b/packages/builder/src/components/integration/codemirror.js
@@ -11,6 +11,7 @@ import "codemirror/mode/handlebars/handlebars"
 // Hints
 import "codemirror/addon/hint/show-hint"
 import "codemirror/addon/hint/show-hint.css"
+import "codemirror/addon/mode/overlay"
 
 // Theming
 import "codemirror/theme/tomorrow-night-eighties.css"

--- a/packages/builder/src/components/integration/index.svelte
+++ b/packages/builder/src/components/integration/index.svelte
@@ -24,6 +24,7 @@ export let schema
 export let editable = true
 export let height = 500
 export let noLabel = false
+export let autoHeight = false
 
 let stepEditors = []
 
@@ -75,6 +76,7 @@ $: shouldDisplayJsonBox =
     {#if schema.type === QueryTypes.SQL}
       <Editor
         editorHeight={height}
+        {autoHeight}
         label={noLabel ? null : "Query"}
         mode={sqlEditorMode}
         on:change={updateQuery}
@@ -85,6 +87,7 @@ $: shouldDisplayJsonBox =
     {:else if shouldDisplayJsonBox}
       <Editor
         editorHeight={height}
+        {autoHeight}
         label={noLabel ? null : "Query"}
         mode="json"
         on:change={updateQuery}


### PR DESCRIPTION
## Description
Improve the SQL query experience with a larger, tabbed query workspace, editable query metadata, schema-aware saving, collapsible results, Grid-based result previews, resizable result columns, and improved SQL/transformer editor behavior.

## Addresses
- https://github.com/SuperToolMake/supertoolmake/issues/35

## Screenshots
<img width="1670" height="787" alt="Screenshot 2026-07-31 at 20 19 17" src="https://github.com/user-attachments/assets/af476a32-0e4e-4380-966c-353d07222bf1" />


## Launchcontrol
Make SQL and non-SQL query editing easier to use by giving users a larger query workspace, clearer controls, better result inspection, and safer saving behavior.

## Task Metrics
- LLM model: `openai/gpt-5.6-luna` (high reasoning)
- Total token usage: `117,288,080`
- Input tokens: `529,917`
- Output tokens: `63,334`
- Reasoning tokens: `110,480`
- Cache read tokens: `116,157,461`
- Cache write tokens: `476,902`
- Dollar spend: `$1.35`

There was an offer on OpenRouter for GPT 5.6 Luna $0.10 IN / $0.60 OUT. 
It is worth noting there is a cached token cost of: $0.01 IN / $0.125 OUT. 
Additionally, reasoning tokens count as output tokens.

So the breakdown:

+ 0.529M x $0.1 (0.0529)
+ 0.063M x $0.6 (0.0378)
+ 0.11M x $0.6 (0.066)
+ 116M x $0.01 (1.16)
+ 0.477M x $0.125 (0.0596)
---------------------
~$1.35

It's interesting that the cached input was the largest cost by far. 

## Additional charge

I was confused because the cost in the OpenRouter dashboard appeared to be about $2.30.
Here was some additional analysis:

```
The discrepancy is real and appears to be caused by OpenRouter’s long-context pricing.
OpenCode calculates cost locally from its cached model pricing:
- Input: $0.10/M
- Output: $0.60/M
- Cache read: $0.01/M
- Cache write: $0.125/M
OpenRouter applies a higher rate when the prompt exceeds 272K tokens:
- Input: $0.20/M
- Output: $0.90/M
- Cache read: $0.02/M
- Cache write: $0.25/M
This task had many large-context requests:
- Approximately 221 requests exceeded the 272K threshold.
- Approximately 118.5M cache-read tokens were used.
- The higher cache-read rate alone adds roughly $0.84.
- Recalculating with OpenRouter’s long-context rates gives approximately $2.297, matching the $2.30 shown by OpenRouter.
So the numbers represent different things:
- OpenCode: local estimate based on its cached base pricing, around $1.35-$1.37.
- OpenRouter: provider-side billing using the applicable long-context rates, around $2.30.
OpenRouter’s usage or generation details are the billing source of truth. The OpenCode UI does not currently appear to account for OpenRouter’s conditional long-context pricing override. The PR metrics section contains the OpenCode estimate, not the authoritative provider charge.
``` 

EDIT: This is not entirely truthful, funny how Luna deflected blame away from OpenAI! 
https://developers.openai.com/api/docs/pricing

